### PR TITLE
Añade StandardJS (eslint)

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "standard"
+}

--- a/package.json
+++ b/package.json
@@ -21,5 +21,13 @@
   "bugs": {
     "url": "https://github.com/adeluccar/epale-bot/issues"
   },
-  "homepage": "https://github.com/adeluccar/epale-bot#readme"
+  "homepage": "https://github.com/adeluccar/epale-bot#readme",
+  "devDependencies": {
+    "eslint": "^=3.19.0",
+    "eslint-config-standard": "^10.2.1",
+    "eslint-plugin-import": "^2.7.0",
+    "eslint-plugin-node": "^5.1.1",
+    "eslint-plugin-promise": "^3.5.0",
+    "eslint-plugin-standard": "^3.0.1"
+  }
 }


### PR DESCRIPTION
La idea es instalar en tu editor de texto preferido el plugin necesario
para correr eslint. El plugin se agarrará de las reglas contenidas en el
modulo eslint-config-standard y del .eslintrc.json para mostrarte
mensajes en tiempo real respecto al estilo de javascript.

https://standardjs.com/readme-esla.html
https://eslint.org/

References #18
Closes #3
Closes #4